### PR TITLE
Preimages STF => CODEC and applyPreimagesStf

### DIFF
--- a/src/__tests__/stf/conformance/preimagesConformance.test.ts
+++ b/src/__tests__/stf/conformance/preimagesConformance.test.ts
@@ -1,0 +1,38 @@
+import fs from "fs";
+import path from "path";
+import { convertToReadableFormat } from "../../../utils";
+import { applyPreimagesStf } from "../../../stf/preimages/applyPreimagesStf";
+import { deepConvertHexToBytes } from "../../../codecs";
+import { CHAIN_TYPE, JAM_TEST_VECTORS } from "../../../consts";
+
+describe("Safrole STF conformance", () => {
+  const testFiles = [
+    "preimage_needed-1",
+    "preimage_needed-2",
+    "preimage_not_needed-1",
+    "preimage_not_needed-2",
+    "preimages_order_check-1",
+    "preimages_order_check-2",
+    "preimages_order_check-3",
+    "preimages_order_check-4"
+
+  ];
+
+  testFiles.forEach((fileName) => {
+    it(`should pass ${fileName}`, () => {
+      
+      const filePath = path.join(`${JAM_TEST_VECTORS}/preimages`, 'data', fileName.concat('.json'));
+      const rawJson = fs.readFileSync(filePath, "utf8");
+
+      const { input, pre_state, output, post_state } = JSON.parse(rawJson);
+      const inputBytes = deepConvertHexToBytes(input);
+      const pre_stateBytes = deepConvertHexToBytes(pre_state);
+
+      const { output: stfOutput, postState } = applyPreimagesStf(pre_stateBytes, inputBytes);
+
+      expect(convertToReadableFormat(stfOutput)).toEqual(output);
+      expect(convertToReadableFormat(postState)).toEqual(post_state);
+
+    });
+  });
+});

--- a/src/__tests__/stf/preimages/preimages.test.ts
+++ b/src/__tests__/stf/preimages/preimages.test.ts
@@ -1,0 +1,75 @@
+import { readFileSync, writeFileSync } from "fs";
+import * as fs from "fs";
+import * as path from "path";
+import { PreimagesStf } from "../../../stf/preimages/types";
+import { PreimagesStfCodec } from "../../../stf/preimages/codecs/PreimagesStfCodec";
+import { toHex, convertToReadableFormat } from "../../../utils";
+import { parsePreimagesStfJson } from "../../../stf/preimages/utils/parsePreimagesStfJson";
+import { CHAIN_TYPE, JAM_TEST_VECTORS } from "../../../consts";
+
+describe("Preimages STF TestCase Codec", () => {
+  it("round-trips from JSON => encode => decode => compare", () => {
+    // 1) Read JSON
+    
+    const jsonPath = path.join(
+      `${JAM_TEST_VECTORS}/preimages`, "data", `preimages_order_check-4.json`
+    );
+    const rawJson = JSON.parse(readFileSync(jsonPath, "utf-8"));
+
+    // 2) Convert JSON 
+    const stfCase = parsePreimagesStfJson(rawJson);
+
+    // 3) Encode
+    const encoded = PreimagesStfCodec.enc(stfCase);
+    // console.log("Encoded stfCase (hex):", (encoded));
+    // console.log("StfCase:", convertToReadableFormat(stfCase));
+
+    // 4) Decode
+    const decoded = PreimagesStfCodec.dec(encoded);
+
+    console.log("Decoded stfCase (readable):", convertToReadableFormat(decoded));
+
+    // 5) Debug files
+    const outDir = path.resolve(__dirname, "../../output/stf/Preimages");
+    writeFileSync(path.join(outDir, "encodedTestCase.txt"), convertToReadableFormat(encoded));
+    writeFileSync(
+      path.join(outDir, "decodedTestCase.json"),
+      JSON.stringify(convertToReadableFormat(decoded), null, 2)
+    );
+
+    // 6) Compare
+    expect(decoded).toStrictEqual(stfCase);
+  });
+
+  it("decodes conformance preimages_order_chec-4.bin => re-encodes => exact match", () => {
+    // 1) read .bin from the same data directory
+    const binPath = path.join(
+      `${JAM_TEST_VECTORS}/preimages`, "data", `preimages_order_check-4.bin`
+    );
+    const rawBin = new Uint8Array(readFileSync(binPath));
+
+    console.log("Conformance binary (hex):", Buffer.from(rawBin).toString("hex"));
+
+    // 2) decode
+    const decoded = PreimagesStfCodec.dec(rawBin);
+    console.log(
+      "Decoded conformance PreimagesStf:",
+      convertToReadableFormat(decoded)
+    );
+
+    // debugging output
+    const outDir = path.resolve(__dirname, "../../output/stf/Preimages");
+    writeFileSync(
+      path.join(outDir, "bin_decodedTestCase.json"),
+      JSON.stringify(convertToReadableFormat(decoded), null, 2)
+    );
+
+    // 3) re-encode
+    const reEncoded = PreimagesStfCodec.enc(decoded);
+    console.log("Re-encoded (hex):", toHex(reEncoded));
+
+    // 4) Compare
+    expect(reEncoded).toEqual(rawBin);
+  });
+}
+);

--- a/src/stf/preimages/applyPreimagesStf.ts
+++ b/src/stf/preimages/applyPreimagesStf.ts
@@ -1,0 +1,116 @@
+
+import { blake2b } from "blakejs";
+import { PreimagesInput, PreimagesOutput, PreimagesState, ErrorCode, PreimagesMapEntry, AccountsMapEntry } from "./types";
+import { compareBytes, toHex } from "../../utils";
+
+export function applyPreimagesStf(
+    preState: PreimagesState,
+    input: PreimagesInput
+  ): { output: PreimagesOutput; postState: PreimagesState } {
+    
+    // 1) Clone pre_state
+    const postState: PreimagesState = structuredClone(preState);
+  
+    // 2) Check sorted + unique
+    // use for loop to get access to prior element
+    for (let i = 1; i < input.preimages.length; i++) {
+    
+      const prevRequester = input.preimages[i - 1].requester;
+      const currRequester = input.preimages[i].requester;
+      const prevBlob = input.preimages[i - 1].blob; 
+      const currBlob = input.preimages[i].blob; 
+
+      if (prevRequester < currRequester) {
+        continue;
+        } else if (prevRequester > currRequester) {
+          console.log("prevRequester and currRequester", prevRequester, currRequester);
+          return { output: { err: ErrorCode.PREIMAGES_NOT_SORTED_UNIQUE }, postState: preState };
+        } else if (prevRequester == currRequester) {
+          if (!isLexicographicallyAscending(prevBlob, currBlob)) {
+          console.log("prevRequester and currRequester", prevRequester, currRequester);
+          return { output: { err: ErrorCode.PREIMAGES_NOT_SORTED_UNIQUE }, postState: preState };
+        } else {
+          continue;
+        }
+      }
+    }
+  
+    // 3) integrate the incoming preimages into the postState
+    for (const p of input.preimages) {
+      
+
+      // i) Check if there is an existing account for p.requester and if not throw error, if so then update. 
+      const requester = p.requester;
+      const account: AccountsMapEntry | undefined = postState.accounts.find((account) => account.id === requester);
+      if (!account) {
+        return { output: { err: ErrorCode.PREIMAGE_UNNEEDED }, postState: preState };
+      }
+      const metaEntry = account.data.lookup_meta.find((meta) => meta.key.length === p.blob.length);
+      console.log("metaEntry", metaEntry);
+
+      // ii) Compute hash of the blob
+      const hash = blake2b(p.blob, undefined, 32);
+      console.log("hashed blake2b", toHex(hash), hash);
+
+      // iii) Check if there is an existing preimage for the hash and if so skip it 
+      const alreadyExistsInPreimage = account.data.preimages.some((m) => compareBytes(m.hash, hash) === 0);
+      console.log("alreadyExists", alreadyExistsInPreimage);
+      if (alreadyExistsInPreimage) {
+        console.log("alreadyExists", alreadyExistsInPreimage);
+        return { output: { err: ErrorCode.PREIMAGE_UNNEEDED }, postState: preState };
+       
+      }
+
+      const alreadyExistsInLookupMeta = account.data.lookup_meta.some((m) => compareBytes(m.key.hash, hash) === 0);
+      if (alreadyExistsInLookupMeta) {
+        console.log("alreadyExistsInLookupMeta", alreadyExistsInLookupMeta);
+      }
+      if (!alreadyExistsInLookupMeta) {
+        // unneded preimage
+        return { output: { err: ErrorCode.PREIMAGE_UNNEEDED }, postState: preState };
+      }
+
+      console.log("we are here", alreadyExistsInLookupMeta);
+
+      // iv) Check if there is an existing meta entry for the hash length and if not throw error, if so then update
+      if (!metaEntry) {
+        // preimage unneeded
+        return { output: { err: ErrorCode.PREIMAGE_UNNEEDED }, postState: preState };
+      }
+
+      if (metaEntry.value.length !== 0) {
+        continue;
+      }
+
+      // v) integrate:
+      //    - Insert (hash, blob) into the accounts preimages
+      account.data.preimages.push({ hash, blob: p.blob });
+
+      //    - Mark the meta as now available => metaEntry.value = [slot]
+      metaEntry.value = [input.slot];
+    }
+
+    // 5) Sort each accounts preimages array by ascending hash
+    for (const acc of postState.accounts) {
+      acc.data.preimages.sort((a, b) => compareBytes(a.hash, b.hash));
+    }
+    
+
+    // 4) Return
+    return { output: { ok: null }, postState };
+  }
+  
+
+
+  function compareBlob(a: Uint8Array, b: Uint8Array): number {
+    for (let i = 0; i < 32; i++) {
+      if (a[i] !== b[i]) 
+        return a[i] - b[i];
+    }
+    return 0;
+  }
+  
+  
+  function isLexicographicallyAscending(prev: Uint8Array, curr: Uint8Array): boolean {
+    return compareBlob(prev, curr) < 0;
+  }

--- a/src/stf/preimages/codecs/AccountCodec.ts
+++ b/src/stf/preimages/codecs/AccountCodec.ts
@@ -1,0 +1,45 @@
+
+import { Codec } from "scale-ts";
+import { DiscriminatorCodec } from "../../../codecs/DiscriminatorCodec";
+import { decodeWithBytesUsed } from "../../../codecs";
+import { concatAll, toUint8Array } from "../../../codecs/utils";
+import { PreimagesMapEntryCodec } from "./PreimagesMapEntryCodec";
+import { LookupMetaMapEntryCodec } from "./LookupMetaMapEntryCodec";
+import { Account, LookupMetaMapEntry, PreimagesMapEntry } from "../types";
+
+const PreimagesMapArrayCodec = DiscriminatorCodec(PreimagesMapEntryCodec);
+const LookupMetaMapArrayCodec = DiscriminatorCodec(LookupMetaMapEntryCodec);
+
+export const AccountCodec: Codec<Account> = [
+  // ENCODER
+  (acc: Account): Uint8Array => {
+    const preimagesEnc = PreimagesMapArrayCodec.enc(acc.preimages);
+    const lookupEnc = LookupMetaMapArrayCodec.enc(acc.lookup_meta);
+    return concatAll(preimagesEnc, lookupEnc);
+  },
+
+  // DECODER
+  (data: ArrayBuffer | Uint8Array | string): Account => {
+    const uint8 = toUint8Array(data);
+    let offset = 0;
+
+    {
+      const slice = uint8.slice(offset);
+      const { value: preimages, bytesUsed } = decodeWithBytesUsed(PreimagesMapArrayCodec, slice);
+      offset += bytesUsed;
+      var preimages_ = preimages as PreimagesMapEntry[];
+    }
+    
+    {
+      const slice = uint8.slice(offset);
+      const { value: lookup_meta, bytesUsed } = decodeWithBytesUsed(LookupMetaMapArrayCodec, slice);
+      offset += bytesUsed;
+      var lookup_meta_ = lookup_meta as LookupMetaMapEntry[];
+    }
+
+    return { preimages: preimages_, lookup_meta: lookup_meta_ };
+  },
+] as unknown as Codec<Account>;
+
+AccountCodec.enc = AccountCodec[0];
+AccountCodec.dec = AccountCodec[1];

--- a/src/stf/preimages/codecs/AccountsMapEntryCodec.ts
+++ b/src/stf/preimages/codecs/AccountsMapEntryCodec.ts
@@ -1,0 +1,33 @@
+
+import { Codec } from "scale-ts";
+import { concatAll, toUint8Array } from "../../../codecs/utils";
+import { u32 } from "scale-ts";
+import { AccountsMapEntry } from "../types";
+import { AccountCodec } from "./AccountCodec";
+
+
+export const AccountsMapEntryCodec: Codec<AccountsMapEntry> = [
+  // ENCODER
+  (ame: AccountsMapEntry): Uint8Array => {
+    const idEnc = u32.enc(ame.id);
+    const dataEnc = AccountCodec.enc(ame.data);
+    return concatAll(idEnc, dataEnc);
+  },
+
+  // DECODER
+  (data: ArrayBuffer | Uint8Array | string): AccountsMapEntry => {
+    const uint8 = toUint8Array(data);
+
+    if (uint8.length < 4) {
+      throw new Error(`AccountsMapEntryCodec: insufficient data for id`);
+    }
+    const id = u32.dec(uint8.slice(0, 4));
+    const accountSlice = uint8.slice(4);
+    const account = AccountCodec.dec(accountSlice);
+
+    return { id, data: account };
+  },
+] as unknown as Codec<AccountsMapEntry>;
+
+AccountsMapEntryCodec.enc = AccountsMapEntryCodec[0];
+AccountsMapEntryCodec.dec = AccountsMapEntryCodec[1];

--- a/src/stf/preimages/codecs/LookupMetaMapEntryCodec.ts
+++ b/src/stf/preimages/codecs/LookupMetaMapEntryCodec.ts
@@ -1,0 +1,41 @@
+import { Codec } from "scale-ts";
+import { DiscriminatorCodec } from "../../../codecs/DiscriminatorCodec";
+import { decodeWithBytesUsed } from "../../../codecs";
+import { concatAll, toUint8Array } from "../../../codecs/utils";
+import { u32 } from "scale-ts";
+import { LookupMetaMapEntry } from "../types";
+import { LookupMetaMapKeyCodec } from "./LookupMetaMapKeyCodec";
+
+const TimeSlotArrayCodec: Codec<number[]> = DiscriminatorCodec<number>(
+  u32,
+);
+
+export const LookupMetaMapEntryCodec: Codec<LookupMetaMapEntry> = [
+  // ENCODER
+  (entry: LookupMetaMapEntry): Uint8Array => {
+    const keyEnc = LookupMetaMapKeyCodec.enc(entry.key);
+    const valEnc = TimeSlotArrayCodec.enc(entry.value);
+    return concatAll(keyEnc, valEnc);
+  },
+
+  // DECODER
+  (data: ArrayBuffer | Uint8Array | string): LookupMetaMapEntry => {
+    const uint8 = toUint8Array(data);
+    let offset = 0;
+
+    if (uint8.length < 36) {
+      throw new Error(`LookupMetaMapEntryCodec: insufficient data for key`);
+    }
+    const key = LookupMetaMapKeyCodec.dec(uint8.slice(offset, offset + 36));
+    offset += 36;
+
+    const slice = uint8.slice(offset);
+    const { value: times, bytesUsed } = decodeWithBytesUsed(TimeSlotArrayCodec, slice);
+    offset += bytesUsed;
+
+    return { key, value: times };
+  },
+] as unknown as Codec<LookupMetaMapEntry>;
+
+LookupMetaMapEntryCodec.enc = LookupMetaMapEntryCodec[0];
+LookupMetaMapEntryCodec.dec = LookupMetaMapEntryCodec[1];

--- a/src/stf/preimages/codecs/LookupMetaMapKeyCodec.ts
+++ b/src/stf/preimages/codecs/LookupMetaMapKeyCodec.ts
@@ -1,0 +1,30 @@
+import { Codec } from "scale-ts";
+import { concatAll, toUint8Array } from "../../../codecs/utils";
+import { u32 } from "scale-ts";
+import { LookupMetaMapKey } from "../types";
+
+
+export const LookupMetaMapKeyCodec: Codec<LookupMetaMapKey> = [
+  // ENCODER
+  (key: LookupMetaMapKey): Uint8Array => {
+    if (key.hash.length !== 32) {
+      throw new Error(`LookupMetaMapKeyCodec: hash must be 32 bytes`);
+    }
+    const lengthEnc = u32.enc(key.length);
+    return concatAll(key.hash, lengthEnc);
+  },
+
+  // DECODER
+  (data: ArrayBuffer | Uint8Array | string): LookupMetaMapKey => {
+    const uint8 = toUint8Array(data);
+    if (uint8.length < 36) {
+      throw new Error(`LookupMetaMapKeyCodec: need 36 bytes total`);
+    }
+    const hash = uint8.slice(0, 32);
+    const length = u32.dec(uint8.slice(32, 36));
+    return { hash, length };
+  },
+] as unknown as Codec<LookupMetaMapKey>;
+
+LookupMetaMapKeyCodec.enc = LookupMetaMapKeyCodec[0];
+LookupMetaMapKeyCodec.dec = LookupMetaMapKeyCodec[1];

--- a/src/stf/preimages/codecs/PreimageCodec.ts
+++ b/src/stf/preimages/codecs/PreimageCodec.ts
@@ -1,0 +1,40 @@
+import { Codec } from "scale-ts";
+import { DiscriminatorCodec } from "../../../codecs/DiscriminatorCodec";
+import { decodeWithBytesUsed } from "../../../codecs";
+import { VarLenBytesCodec } from "../../../codecs/VarLenBytesCodec"; 
+import { toUint8Array, concatAll } from "../../../codecs/utils";
+import { u32 } from "scale-ts";
+import { Preimage } from "../types";
+
+export const PreimageCodec: Codec<Preimage> = [
+  // ENCODER
+  (p: Preimage): Uint8Array => {
+    const requesterEnc = u32.enc(p.requester);
+    const blobEnc = VarLenBytesCodec.enc(p.blob);
+
+    return concatAll(requesterEnc, blobEnc);
+  },
+
+  // DECODER
+  (data: ArrayBuffer | Uint8Array | string): Preimage => {
+    const uint8 = toUint8Array(data);
+    let offset = 0;
+
+    if (offset + 4 > uint8.length) {
+      throw new Error(`PreimageCodec: insufficient data for requester`);
+    }
+    const requester = u32.dec(uint8.slice(offset, offset + 4));
+    offset += 4;
+
+    const slice = uint8.slice(offset);
+    const { value: blob, bytesUsed } = decodeWithBytesUsed(VarLenBytesCodec, slice);
+    offset += bytesUsed;
+
+    return { requester, blob };
+  },
+] as unknown as Codec<Preimage>;
+
+PreimageCodec.enc = PreimageCodec[0];
+PreimageCodec.dec = PreimageCodec[1];
+
+export const PreimagesExtrinsicCodec: Codec<Preimage[]> = DiscriminatorCodec<Preimage>(PreimageCodec);

--- a/src/stf/preimages/codecs/PreimagesInputCodec.ts
+++ b/src/stf/preimages/codecs/PreimagesInputCodec.ts
@@ -1,0 +1,40 @@
+import { Codec } from "scale-ts";
+import { decodeWithBytesUsed } from "../../../codecs";
+import { concatAll, toUint8Array } from "../../../codecs/utils";
+import { u32 } from "scale-ts";
+import { PreimagesInput } from "../types";
+import { PreimagesExtrinsicCodec } from "./PreimageCodec";
+
+
+export const PreimagesInputCodec: Codec<PreimagesInput> = [
+  // ENCODER
+  (inp: PreimagesInput): Uint8Array => {
+    const slotEnc = u32.enc(inp.slot);
+    const extEnc = PreimagesExtrinsicCodec.enc(inp.preimages);
+    return concatAll(extEnc, slotEnc);
+  },
+
+  // DECODER
+  (data: ArrayBuffer | Uint8Array | string): PreimagesInput => {
+    const uint8 = toUint8Array(data);
+    let offset = 0;
+
+    {
+      const slice = uint8.slice(offset);
+      const { value: preimages, bytesUsed } = decodeWithBytesUsed(PreimagesExtrinsicCodec, slice);
+      offset += bytesUsed;
+      var preimages_ = preimages;
+    }
+
+    if (offset + 4 > uint8.length) {
+      throw new Error(`PreimagesInputCodec: insufficient data for slot`);
+    }
+    const slot = u32.dec(uint8.slice(offset, offset + 4));
+    offset += 4;
+
+    return { preimages: preimages_, slot };
+  },
+] as unknown as Codec<PreimagesInput>;
+
+PreimagesInputCodec.enc = PreimagesInputCodec[0];
+PreimagesInputCodec.dec = PreimagesInputCodec[1];

--- a/src/stf/preimages/codecs/PreimagesMapEntryCodec.ts
+++ b/src/stf/preimages/codecs/PreimagesMapEntryCodec.ts
@@ -1,0 +1,40 @@
+import { Codec } from "scale-ts";
+import { VarLenBytesCodec } from "../../../codecs/VarLenBytesCodec";
+import { decodeWithBytesUsed } from "../../../codecs";
+import { toUint8Array, concatAll } from "../../../codecs/utils";
+import { PreimagesMapEntry } from "../types";
+
+export const PreimagesMapEntryCodec: Codec<PreimagesMapEntry> = [
+  // ENCODER
+  (entry: PreimagesMapEntry): Uint8Array => {
+    if (entry.hash.length !== 32) {
+      throw new Error(`PreimagesMapEntryCodec: hash must be 32 bytes`);
+    }
+    const blobEnc = VarLenBytesCodec.enc(entry.blob);
+
+    return concatAll(entry.hash, blobEnc);
+  },
+
+  // DECODER
+  (data: ArrayBuffer | Uint8Array | string): PreimagesMapEntry => {
+    const uint8 = toUint8Array(data);
+    let offset = 0;
+
+    if (uint8.length < 32) {
+      throw new Error(
+        `PreimagesMapEntryCodec: insufficient data for hash (need 32 bytes, got ${uint8.length})`
+      );
+    }
+    const hash = uint8.slice(offset, offset + 32);
+    offset += 32;
+
+    const slice = uint8.slice(offset);
+    const { value: blob, bytesUsed } = decodeWithBytesUsed(VarLenBytesCodec, slice);
+    offset += bytesUsed;
+
+    return { hash, blob };
+  },
+] as unknown as Codec<PreimagesMapEntry>;
+
+PreimagesMapEntryCodec.enc = PreimagesMapEntryCodec[0];
+PreimagesMapEntryCodec.dec = PreimagesMapEntryCodec[1];

--- a/src/stf/preimages/codecs/PreimagesOutputCodec.ts
+++ b/src/stf/preimages/codecs/PreimagesOutputCodec.ts
@@ -1,0 +1,54 @@
+import { Codec } from "scale-ts";
+import { toUint8Array } from "../../../codecs/utils";
+import { PREIMAGES_ERROR_CODES, ErrorCode, PreimagesOutput } from "../types";
+
+export const PreimagesOutputCodec: Codec<PreimagesOutput> = [
+  // ENCODER
+  (out: PreimagesOutput): Uint8Array => {
+    if ("err" in out) {
+
+      const errByte = errorCodeToByte.get(out.err);
+      if (errByte === undefined) {
+        throw new Error(`PreimagesOutputCodec.enc: unknown error code='${out.err}'`);
+      }
+      return new Uint8Array([0x01, errByte]);
+    }
+    return new Uint8Array([0x00]);
+  },
+
+  // DECODER
+  (data: ArrayBuffer | Uint8Array | string): PreimagesOutput => {
+    const uint8 = toUint8Array(data);
+    if (uint8.length < 1) {
+      throw new Error("PreimagesOutputCodec.dec: not enough data for tag");
+    }
+    const tag = uint8[0];
+    if (tag === 0x00) {
+      // => ok
+      return { ok: null };
+    } else if (tag === 0x01) {
+      // => err
+      if (uint8.length < 2) {
+        throw new Error("PreimagesOutputCodec.dec: not enough data for error code");
+      }
+      const errByte = uint8[1];
+      const err = byteToErrorCode(errByte);
+      return { err };
+    }
+    throw new Error(`PreimagesOutputCodec.dec: invalid tag byte ${tag}`);
+  },
+] as unknown as Codec<PreimagesOutput>;
+
+PreimagesOutputCodec.enc = PreimagesOutputCodec[0];
+PreimagesOutputCodec.dec = PreimagesOutputCodec[1];
+
+
+const errorCodeToByte = new Map<ErrorCode, number>();
+PREIMAGES_ERROR_CODES.forEach((code, i) => errorCodeToByte.set(code, i));
+
+function byteToErrorCode(b: number): ErrorCode {
+  if (b < 0 || b >= PREIMAGES_ERROR_CODES.length) {
+    throw new Error(`PreimagesOutputCodec: invalid error code byte=${b}`);
+  }
+  return PREIMAGES_ERROR_CODES[b];
+}

--- a/src/stf/preimages/codecs/PreimagesStateCodec.ts
+++ b/src/stf/preimages/codecs/PreimagesStateCodec.ts
@@ -1,0 +1,26 @@
+import { Codec } from "scale-ts";
+import { DiscriminatorCodec } from "../../../codecs/DiscriminatorCodec";
+import { decodeWithBytesUsed } from "../../../codecs";
+import { toUint8Array } from "../../../codecs/utils";
+import { AccountsMapEntryCodec } from "./AccountsMapEntryCodec";
+import { PreimagesState } from "../types";
+
+
+const AccountsMapArrayCodec = DiscriminatorCodec(AccountsMapEntryCodec);
+
+export const PreimagesStateCodec: Codec<PreimagesState> = [
+  // ENCODER
+  (st: PreimagesState): Uint8Array => {
+    return AccountsMapArrayCodec.enc(st.accounts);
+  },
+
+  // DECODER
+  (data: ArrayBuffer | Uint8Array | string): PreimagesState => {
+    const uint8 = toUint8Array(data);
+    const { value: accounts } = decodeWithBytesUsed(AccountsMapArrayCodec, uint8);
+    return { accounts };
+  },
+] as unknown as Codec<PreimagesState>;
+
+PreimagesStateCodec.enc = PreimagesStateCodec[0];
+PreimagesStateCodec.dec = PreimagesStateCodec[1];

--- a/src/stf/preimages/codecs/PreimagesStfCodec.ts
+++ b/src/stf/preimages/codecs/PreimagesStfCodec.ts
@@ -1,0 +1,75 @@
+import { Codec } from "scale-ts";
+import { decodeWithBytesUsed } from "../../../codecs";
+import { concatAll, toUint8Array } from "../../../codecs/utils";
+import { PreimagesInput, PreimagesOutput, PreimagesState, PreimagesStf } from "../types";
+import { PreimagesInputCodec } from "./PreimagesInputCodec";
+import { PreimagesOutputCodec } from "./PreimagesOutputCodec";
+import { PreimagesStateCodec } from "./PreimagesStateCodec";
+
+
+export const PreimagesStfCodec: Codec<PreimagesStf> = [
+    // ENCODER
+    (testCase: PreimagesStf): Uint8Array => {
+      const encInput = PreimagesInputCodec.enc(testCase.input);
+      const encPreState = PreimagesStateCodec.enc(testCase.pre_state);
+      const encOutput = PreimagesOutputCodec.enc(testCase.output);
+      const encPostState = PreimagesStateCodec.enc(testCase.post_state);
+      return concatAll(encInput, encPreState, encOutput, encPostState);
+    },
+  
+    // DECODER
+    (data: ArrayBuffer | Uint8Array | string): PreimagesStf => {
+      const uint8 = toUint8Array(data);
+      let offset = 0;
+  
+      // input
+      {
+        const slice = uint8.slice(offset);
+        const { value: input, bytesUsed } = decodeWithBytesUsed(PreimagesInputCodec, slice);
+        offset += bytesUsed;
+        var input_ = input;
+      }
+  
+      // pre_state
+      {
+        const slice = uint8.slice(offset);
+        const { value: preState, bytesUsed } = decodeWithBytesUsed(PreimagesStateCodec, slice);
+        offset += bytesUsed;
+        var pre_state_ = preState;
+      }
+  
+      // output
+      {
+        const slice = uint8.slice(offset);
+        const { value: output, bytesUsed } = decodeWithBytesUsed(PreimagesOutputCodec, slice);
+        offset += bytesUsed;
+        var output_ = output;
+      }
+  
+      // post_state
+      {
+        const slice = uint8.slice(offset);
+        const { value: postState, bytesUsed } = decodeWithBytesUsed(PreimagesStateCodec, slice);
+        offset += bytesUsed;
+        var post_state_ = postState;
+      }
+  
+      if (offset < uint8.length) {
+        console.warn(
+          `PreimagesStfCodec: leftover bytes (offset=${offset}, total=${uint8.length})`
+        );
+      }
+  
+      return {
+        input: input_ as PreimagesInput,
+        pre_state: pre_state_ as PreimagesState,
+        output: output_ as PreimagesOutput,
+        post_state: post_state_ as PreimagesState,
+      };
+    },
+  ] as unknown as Codec<PreimagesStf>;
+  
+  PreimagesStfCodec.enc = PreimagesStfCodec[0];
+  PreimagesStfCodec.dec = PreimagesStfCodec[1];
+  
+  

--- a/src/stf/preimages/types.ts
+++ b/src/stf/preimages/types.ts
@@ -1,0 +1,61 @@
+
+
+
+export type PreimagesOutput = { ok: null } | { err: ErrorCode };
+
+export interface Preimage {
+  requester: number;  // 4 bytes
+  blob: Uint8Array;   // variable
+}
+
+export interface PreimagesMapEntry {
+  hash: Uint8Array;  // 32 bytes
+  blob: Uint8Array;  // variable
+}
+
+export interface LookupMetaMapKey {
+  hash: Uint8Array; // 32 bytes
+  length: number;   // u32
+}
+
+export interface LookupMetaMapEntry {
+  key: LookupMetaMapKey;
+  value: number[];  // TODO an array of up to 3 timeslots?
+}
+
+export interface Account {
+  preimages: PreimagesMapEntry[];
+  lookup_meta: LookupMetaMapEntry[];
+}
+
+export interface AccountsMapEntry {
+  id: number;    // 4 bytes
+  data: Account; 
+}
+
+export interface PreimagesState {
+  accounts: AccountsMapEntry[];
+}
+
+export interface PreimagesInput {
+  preimages: Preimage[];
+  slot: number;
+}
+
+export interface PreimagesStf {
+  input: PreimagesInput;
+  pre_state: PreimagesState;
+  output: PreimagesOutput;
+  post_state: PreimagesState;
+}
+
+export enum ErrorCode {
+  PREIMAGE_UNNEEDED = "preimage_unneeded",
+  PREIMAGES_NOT_SORTED_UNIQUE = "preimages_not_sorted_unique"
+}
+
+export const PREIMAGES_ERROR_CODES: ErrorCode[] = [
+  ErrorCode.PREIMAGE_UNNEEDED,
+  ErrorCode.PREIMAGES_NOT_SORTED_UNIQUE
+];
+

--- a/src/stf/preimages/utils/parsePreimagesStfJson.ts
+++ b/src/stf/preimages/utils/parsePreimagesStfJson.ts
@@ -1,0 +1,110 @@
+import { PreimagesStf, PreimagesInput, PreimagesOutput, PreimagesState } from "../types";
+import { Preimage, PreimagesMapEntry, LookupMetaMapEntry, LookupMetaMapKey, Account, AccountsMapEntry } from "../types";
+import { hexStringToBytes } from "../../../codecs"; // or wherever your hex-to-bytes util is
+
+/**
+ * parsePreimagesStfJson:
+ *   Converts the raw JSON for a Preimages STF test case into a PreimagesStf object.
+ */
+export function parsePreimagesStfJson(json: any): PreimagesStf {
+  return {
+    input: parsePreimagesInputJson(json.input),
+    pre_state: parsePreimagesStateJson(json.pre_state),
+    output: parsePreimagesOutputJson(json.output),
+    post_state: parsePreimagesStateJson(json.post_state),
+  };
+}
+
+
+export function parsePreimagesInputJson(json: any): PreimagesInput {
+  if (!json) {
+    throw new Error("parsePreimagesInputJson: missing input JSON");
+  }
+
+  const preimages = (json.preimages || []).map((p: any) => parsePreimageJson(p));
+  const slot = json.slot || 0;
+
+  return { preimages, slot };
+}
+
+function parsePreimageJson(json: any): Preimage {
+  return {
+    requester: json.requester || 0,
+    blob: json.blob ? hexStringToBytes(json.blob) : new Uint8Array(),
+  };
+}
+
+export function parsePreimagesStateJson(json: any): PreimagesState {
+  if (!json) {
+    return { accounts: [] };
+  }
+  const accounts = (json.accounts || []).map((accJson: any) =>
+    parseAccountsMapEntryJson(accJson)
+  );
+  return { accounts };
+}
+
+function parseAccountsMapEntryJson(json: any): AccountsMapEntry {
+  return {
+    id: json.id || 0,
+    data: parseAccountJson(json.data),
+  };
+}
+
+function parseAccountJson(json: any): Account {
+  if (!json) {
+    return {
+      preimages: [],
+      lookup_meta: [],
+    };
+  }
+
+  const preimages = (json.preimages || []).map((p: any) => parsePreimagesMapEntryJson(p));
+  const lookup_meta = (json.lookup_meta || []).map((lm: any) => parseLookupMetaMapEntryJson(lm));
+
+  return {
+    preimages,
+    lookup_meta,
+  };
+}
+
+function parsePreimagesMapEntryJson(json: any): PreimagesMapEntry {
+  return {
+    hash: json.hash ? hexStringToBytes(json.hash) : new Uint8Array(),
+    blob: json.blob ? hexStringToBytes(json.blob) : new Uint8Array(),
+  };
+}
+
+function parseLookupMetaMapEntryJson(json: any): LookupMetaMapEntry {
+  return {
+    key: parseLookupMetaMapKeyJson(json.key),
+    value: (json.value || []).map((slot: any) => slot >>> 0), 
+  };
+}
+
+function parseLookupMetaMapKeyJson(json: any): LookupMetaMapKey {
+  if (!json) {
+    return {
+      hash: new Uint8Array(32),
+      length: 0,
+    };
+  }
+  return {
+    hash: json.hash ? hexStringToBytes(json.hash) : new Uint8Array(32),
+    length: json.length || 0,
+  };
+}
+
+export function parsePreimagesOutputJson(json: any): PreimagesOutput {
+  if (!json) {
+    return { ok: null };
+  }
+
+  if (json.ok !== undefined) {
+    return { ok: null };
+  } else if (json.err !== undefined) {
+    return { err: json.err };
+  }
+
+  return { ok: null };
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -61,3 +61,18 @@ export function ensureBinary(field: any, expectedLength: number, fieldName: stri
   }
   return field;
 }
+
+
+  // helper to compare two byte arrays lexicographically, 
+  // returns number
+  export function compareBytes(a: Uint8Array, b: Uint8Array): number {
+
+    // len gets the minimum length of the two arrays
+    const len = Math.min(a.length, b.length);
+    for (let i = 0; i < len; i++) {
+      if (a[i] !== b[i]) {
+        return a[i] - b[i];
+      }
+    }
+    return a.length - b.length;
+  }


### PR DESCRIPTION
**Preimages STF => Codec**

- ✅ Codec check passed (stf/preimages/preimages.test.ts)
- TODO: check if the integer encoding is correct, i.e. compact encoding C.6; and scale encoding is used in some instances.


**Preimages STF => applyPreimagesStf**

- ✅ 8/8 conformance tests passed.

- Checks preimages are sorted and unique,
- Checks if preimages are needed. If there was no lookup request then no preimages are needed.
- When preimages are needed, then it updates the meta lookup with the slot number, and adds the preimages hash and blob to the preimages map